### PR TITLE
Create main page and sub components

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -22,6 +22,7 @@ import authTest from './pages/AUTH-TEST';
 // Auth Helper
 import withAuthentication from './components/AuthUserSession/withAuthentication';
 import ModalConductor from './components/Modals/ModalConductor'
+import MainPageContainer from './pages/Main/MainPageContainer';
 class App extends Component {
   constructor(props) {
     super(props);
@@ -58,9 +59,11 @@ class App extends Component {
             closeModal={this.closeModal}
           />
           <Switch>
-            <Route exact path='/' component={Home} />
+            {/* <Route exact path='/' component={Home} /> */}
+            <Route exact path='/' component={MainPageContainer} />
             <Route exact path='/home' component={Home} />
-            <Route exact path='/categories/:categoryName' component={MainCategoryPage} />
+            {/* <Route exact path='/categories/:categoryName' component={MainCategoryPage} /> */}
+            <Route exact path='/categories/:categoryName' component={MainPageContainer} />
             <Route exact path='/categories/:categoryName/posts/new' component={Editor} />
             <Route exact path='/posts/:id' component={Content} />
             <Route exact path='/posts/:postId/edit' component={Editor} />

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -8,13 +8,13 @@ import SubNav from './components/subNav';
 import FlexContainer from './components/flexContainer';
 // import API from './utils/API';
 //Routes
-import Home from './pages/Home';
+// import Home from './pages/Home';
 import Editor from './pages/Editor'
 import Content from './pages/Content';
 import NoMatch from './pages/NoMatch';
 // import * as routes from './constants/routes';
 import AccountPage from './pages/Account';
-import MainCategoryPage from './pages/MainCategoryPage';
+// import MainCategoryPage from './pages/MainCategoryPage';
 import Profile from './pages/Profile';
 
 import authTest from './pages/AUTH-TEST';
@@ -61,7 +61,7 @@ class App extends Component {
           <Switch>
             {/* <Route exact path='/' component={Home} /> */}
             <Route exact path='/' component={MainPageContainer} />
-            <Route exact path='/home' component={Home} />
+            {/* <Route exact path='/home' component={Home} /> */}
             {/* <Route exact path='/categories/:categoryName' component={MainCategoryPage} /> */}
             <Route exact path='/categories/:categoryName' component={MainPageContainer} />
             <Route exact path='/categories/:categoryName/posts/new' component={Editor} />

--- a/client/src/components/IntroHeader/IntroHeader.js
+++ b/client/src/components/IntroHeader/IntroHeader.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import AuthUserContext from '../AuthUserSession/AuthUserContext'
+
+// this is just a placeholder for now
+
+const IntroHeader = props => {
+  return (
+    <AuthUserContext.Consumer>
+      {authUser => !authUser &&
+        <div className='w-full bg-grey border-black rounded h-screen px-3 py-16'>
+          <h2 className='text-grey-darker text-5xl'>Intro Header</h2>
+        </div>}
+    </AuthUserContext.Consumer>
+  )
+}
+
+export default IntroHeader

--- a/client/src/components/IntroHeader/index.js
+++ b/client/src/components/IntroHeader/index.js
@@ -1,0 +1,1 @@
+export { default } from './IntroHeader'

--- a/client/src/components/Sidebar/SBTagFilter.js
+++ b/client/src/components/Sidebar/SBTagFilter.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import SideBarSection from './SidebarSection'
+
+const SBTagFilter = props => {
+  if (!props.tags || props.tags.length < 1) {
+    return null
+  }
+
+  return (
+    <SideBarSection>
+      <p className='text-left font-bold mb-1'>Tags</p>
+      {props.tags.sort().map(tag => (
+        <li className='tagLink rounded tagLinkInactive' key={tag} onClick={(event) => props.toggleSelectTag(event, tag)}>
+          {tag}
+        </li>
+      ))}
+    </SideBarSection>
+  )
+}
+
+export default SBTagFilter
+

--- a/client/src/components/Sidebar/Sidebar.js
+++ b/client/src/components/Sidebar/Sidebar.js
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const Sidebar = props => {
+  return (
+    <div className='bg-white border-grey rounded p-1 m-1'>
+      {props.children}
+    </div>
+  )
+}
+
+export default Sidebar

--- a/client/src/components/Sidebar/SidebarSection.js
+++ b/client/src/components/Sidebar/SidebarSection.js
@@ -1,0 +1,29 @@
+import React from 'react'
+
+const SidebarSection = props => {
+  // types header, body, footer
+  // const headerClasses = 'my-0'
+  const bodyClasses = 'border-grey border-l-0 border-r-0 my-0'
+  // const footerClasses = 'my-0'
+
+  let classes = 'my-0'
+  // if (props.type === 'header') {
+  //   classes = headerClasses
+  // }
+
+  if (props.type === 'body') {
+    classes = bodyClasses
+  }
+
+  // if (props.type === 'footer') {
+  //   classes = footerClasses
+  // }
+
+  return (
+    <div className={classes}>
+      {props.children}
+    </div>
+  )
+}
+
+export default SidebarSection

--- a/client/src/components/Widgets/List.js
+++ b/client/src/components/Widgets/List.js
@@ -1,0 +1,29 @@
+import React from 'react'
+
+const List = props => {
+  console.log('List props: ', props)
+  // default List styles
+  let classes = 'm-1 p-1 bg-white border-medium-gray rounded '
+
+  // allow adding style classes to end of default class string
+  // note that this does not always work as expected... 
+  // e.g. adding 'bg-blue' on props.className will not overwrite 'bg-white'
+  if (props.mergeClasses) {
+    classes += props.className
+  }
+
+  // allow overwriting of styles
+  if (!props.mergeClasses && props.className && typeof(props.className === 'string')) {
+    classes = props.className
+  }
+
+  return (
+    <div className={classes}>
+      {props.data.map(itemProps => {
+        return React.createElement(props.component, { key: itemProps[props.keyProp], ...itemProps }, null)
+      })}
+    </div>
+  )
+}
+
+export default List

--- a/client/src/components/Widgets/List.js
+++ b/client/src/components/Widgets/List.js
@@ -1,7 +1,6 @@
 import React from 'react'
 
 const List = props => {
-  console.log('List props: ', props)
   // default List styles
   let classes = 'm-1 p-1 bg-white border-medium-gray rounded '
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -11,7 +11,7 @@ body {
   font-family: 'Montserrat', sans-serif;
   color: #333333;
   padding-top: 70px;
-  overflow: hidden;
+  /* overflow: hidden; */
   margin: 0;
 }
 /* Need to keep */

--- a/client/src/pages/Main/MainPage.js
+++ b/client/src/pages/Main/MainPage.js
@@ -1,78 +1,56 @@
 import React from 'react'
-import List from '../../components/Widgets/List';
+import { Link } from 'react-router-dom'
 import { PostListItem } from '../../components/PostComponents/PostListDisplay';
+import { Button } from '../../components/Widgets/Button'
+import List from '../../components/Widgets/List';
+import Sidebar from '../../components/Sidebar/Sidebar'
+import AuthUserContext from '../../components/AuthUserSession/AuthUserContext'
+import SBTagFilter from '../../components/Sidebar/SBTagFilter';
+import IntroHeader from '../../components/IntroHeader'
 
 const MainPage = props => (
   // introduction header goes here...
-  <div className='w-full flex'>
-    <div className='w-4/5 p-1'>
+  <div className='w-full'>
 
-     {/* conditionally render the category display  */}
-      {props.categoryDisplayName &&
-        <div className='bg-white border-grey rounded m-1 p-3'>
-          <h3>{props.categoryDisplayName}</h3>
-          <p className='text-sm'>{props.categoryDescription}</p>
-        </div>}
+    <IntroHeader />
 
-      <PostList data={props.posts} />
+    <div>
+      <AuthUserContext.Consumer>
+        {authUser => authUser ?
+          <Link to={{ pathname: `/editor` }}>
+            <Button text='Create Post' />
+          </Link> : null}
+      </AuthUserContext.Consumer>
     </div>
 
-    <div className='w-1/5'>
-      <Sidebar>
-        {/* <SBCategoryDescription
-          categoryDisplayName={props.categoryDisplayName}
-          categoryDescription={props.categoryDescription}
-         /> */}
-      </Sidebar>
+    <div className='w-full flex mx-0'>
+      {/* left column container, main content */}
+      <div className='w-4/5'>
+        {/* conditionally render the category display  */}
+        {props.categoryDisplayName &&
+          <div className='bg-white border-grey rounded m-1 p-3'>
+            <h3>{props.categoryDisplayName}</h3>
+            <p className='text-sm'>{props.categoryDescription}</p>
+          </div>}
+
+        <PostList data={props.filteredPosts} />
+      </div>
+
+      {/* right column container, sidebar */}
+      <div className='w-1/5'>
+        <Sidebar>
+          <SBTagFilter
+            toggleSelectTag={props.toggleSelectTag}
+            tags={props.categoryTags}
+          />
+        </Sidebar>
+      </div>
     </div>
   </div>
 )
 
 const PostList = props => {
   return <List data={props.data} keyProp='_id' component={PostListItem} />
-}
-
-const Sidebar = props => {
-  return (
-    <div>
-      {props.children}
-    </div>
-  )
-}
-
-const SidebarSection = props => {
-  // types header, body, footer
-  const headerClasses = 'bg-white border-grey rounded-t p-1 mb-0'
-  const bodyClasses = 'bg-white border-grey border-t-0 p-1 my-0'
-  const footerClasses = 'bg-white border-grey border-t-0 rounded-b p-1 mt-0'
-
-  let classes = ''
-  if (props.type === 'header') {
-    classes = headerClasses
-  }
-
-  if (props.type === 'body') {
-    classes = bodyClasses
-  }
-
-  if (props.type === 'footer') {
-    classes = footerClasses
-  }
-
-  return (
-    <div className={classes}>
-      {props.children}
-    </div>
-  )
-}
-
-const SBCategoryDescription = props => {
-  return (
-    <SidebarSection type='header'>
-      <React.Fragment>
-      </React.Fragment>
-    </SidebarSection>
-  )
 }
 
 export default MainPage

--- a/client/src/pages/Main/MainPage.js
+++ b/client/src/pages/Main/MainPage.js
@@ -1,0 +1,78 @@
+import React from 'react'
+import List from '../../components/Widgets/List';
+import { PostListItem } from '../../components/PostComponents/PostListDisplay';
+
+const MainPage = props => (
+  // introduction header goes here...
+  <div className='w-full flex'>
+    <div className='w-4/5 p-1'>
+
+     {/* conditionally render the category display  */}
+      {props.categoryDisplayName &&
+        <div className='bg-white border-grey rounded m-1 p-3'>
+          <h3>{props.categoryDisplayName}</h3>
+          <p className='text-sm'>{props.categoryDescription}</p>
+        </div>}
+
+      <PostList data={props.posts} />
+    </div>
+
+    <div className='w-1/5'>
+      <Sidebar>
+        {/* <SBCategoryDescription
+          categoryDisplayName={props.categoryDisplayName}
+          categoryDescription={props.categoryDescription}
+         /> */}
+      </Sidebar>
+    </div>
+  </div>
+)
+
+const PostList = props => {
+  return <List data={props.data} keyProp='_id' component={PostListItem} />
+}
+
+const Sidebar = props => {
+  return (
+    <div>
+      {props.children}
+    </div>
+  )
+}
+
+const SidebarSection = props => {
+  // types header, body, footer
+  const headerClasses = 'bg-white border-grey rounded-t p-1 mb-0'
+  const bodyClasses = 'bg-white border-grey border-t-0 p-1 my-0'
+  const footerClasses = 'bg-white border-grey border-t-0 rounded-b p-1 mt-0'
+
+  let classes = ''
+  if (props.type === 'header') {
+    classes = headerClasses
+  }
+
+  if (props.type === 'body') {
+    classes = bodyClasses
+  }
+
+  if (props.type === 'footer') {
+    classes = footerClasses
+  }
+
+  return (
+    <div className={classes}>
+      {props.children}
+    </div>
+  )
+}
+
+const SBCategoryDescription = props => {
+  return (
+    <SidebarSection type='header'>
+      <React.Fragment>
+      </React.Fragment>
+    </SidebarSection>
+  )
+}
+
+export default MainPage

--- a/client/src/pages/Main/MainPageContainer.js
+++ b/client/src/pages/Main/MainPageContainer.js
@@ -31,6 +31,28 @@ class MainPageContainer extends React.Component {
     }
   }
 
+  toggleSelectTag = (event, tag) => {
+    event.target.classList.toggle('tagLinkInactive');
+    event.target.classList.toggle('tagLinkActive');
+
+    let selectedTags, filteredPosts
+    if (this.state.selectedTags.includes(tag)) {
+      selectedTags = this.state.selectedTags.filter(t => t !== tag)
+    } else {
+      selectedTags = this.state.selectedTags.concat(tag).sort()
+    }
+
+    if (selectedTags.length === 0) {
+      filteredPosts = this.state.posts
+    } else {
+      filteredPosts = this.state.posts.filter(post => {
+        return post.tags.some(t => selectedTags.includes(t))
+      })
+    }
+
+    this.setState({ selectedTags, filteredPosts })
+  }
+
   fetchData() {
     const p = this.props
     const categoryName = (p.match && p.match.params.categoryName) || null
@@ -50,7 +72,8 @@ class MainPageContainer extends React.Component {
           categoryDisplayName: category.displayName,
           categoryDescription: category.description,
           categoryTags: category.tags,
-          posts: posts
+          posts: posts,
+          filteredPosts: posts
         })
       })
       .catch(err => console.log('fetchCategoryAndPosts Err: ', err))
@@ -59,12 +82,12 @@ class MainPageContainer extends React.Component {
   fetchDefault() {
     return API.getAllPosts()
       .then(result => result.data)
-      .then(posts => this.setState({ ...nullCategory, posts }))
+      .then(posts => this.setState({ filteredPosts: posts, ...nullCategory, posts }))
       .catch(err => console.log('fetchDefault Err: ', err))
   }
 
   render() {
-    return <MainPage {...this.state} />
+    return <MainPage toggleSelectTag={this.toggleSelectTag} {...this.state} />
   }
 }
 

--- a/client/src/pages/Main/MainPageContainer.js
+++ b/client/src/pages/Main/MainPageContainer.js
@@ -1,0 +1,71 @@
+import React from 'react'
+import MainPage from './MainPage'
+import API from '../../utils/API';
+
+const nullCategory = {
+  categoryName: '',
+  categoryDisplayName: '',
+  categoryDescription: '',
+  categoryTags: [],
+  categorySettings: null,
+}
+
+class MainPageContainer extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      posts: [],
+      filteredPosts: [],
+      selectedTags: [],
+      ...nullCategory
+    }
+  }
+
+  componentDidMount() {
+    this.fetchData()
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.match.params.categoryName !== prevProps.match.params.categoryName) {
+      this.fetchData();
+    }
+  }
+
+  fetchData() {
+    const p = this.props
+    const categoryName = (p.match && p.match.params.categoryName) || null
+    if (categoryName) {
+      this.fetchCategoryAndPosts(categoryName)
+    } else {
+      this.fetchDefault()
+    }
+  }
+
+  fetchCategoryAndPosts(categoryName) {
+    return API.getCategoryAndPosts(categoryName)
+      .then(result => result.data)
+      .then(({ category, posts }) => {
+        this.setState({
+          categoryName: category.name,
+          categoryDisplayName: category.displayName,
+          categoryDescription: category.description,
+          categoryTags: category.tags,
+          posts: posts
+        })
+      })
+      .catch(err => console.log('fetchCategoryAndPosts Err: ', err))
+  }
+
+  fetchDefault() {
+    return API.getAllPosts()
+      .then(result => result.data)
+      .then(posts => this.setState({ ...nullCategory, posts }))
+      .catch(err => console.log('fetchDefault Err: ', err))
+  }
+
+  render() {
+    return <MainPage {...this.state} />
+  }
+}
+
+export default MainPageContainer

--- a/client/src/pages/Main/index.js
+++ b/client/src/pages/Main/index.js
@@ -1,0 +1,1 @@
+export { default } from './MainPageContainer'

--- a/client/src/utils/API.js
+++ b/client/src/utils/API.js
@@ -36,6 +36,11 @@ export default {
     //console.log(categoryName)
     return axios.get(`/api/categories/${categoryName}/posts`);
   },
+
+  getCategoryAndPosts: (categoryName) => {
+    return axios.get(`/api/categories/${categoryName}/posts`)
+  },
+  
   getCategoryInfo: (categoryName) => {
     console.log("getting Category Info")
     return axios.get(`/api/categories/info/${categoryName}`, {

--- a/docs/MainPage.md
+++ b/docs/MainPage.md
@@ -1,16 +1,13 @@
-# Index
+# Main Page
 This is the primary content discovery view for Listoka.  It shows a list of
 posts and a sidebar with context aware content.
 
-## Index Page
+## Main Page Component
 - 'Dumb' component, this does not maintain its own state
-- Receives ReactRouter props
-- Renders the view by passing a render function into the `IndexContainer`
-  component
-- Sets structure and styles for page inside the render function passed into
-  `IndexContainer`
+- Is rendered by `MainPageContainer`
+- Sets structure and styles for page 
 
-## Index Container
+## Main Page Container
 - 'Smart' Component
 - Makes network request and stores state for:
     - Category Info (if applicable)
@@ -19,8 +16,8 @@ posts and a sidebar with context aware content.
 - Defines functions for interacting with page (including but not limited to):
     - Filter posts by tags
     - Pagination for loaded posts
-- Does *not* determine any structure or styles.  Instead, it receives a function
-  on its 'render prop' and uses that to determine what to actually render.
+- Renders `MainPage` component
+- Does *not* determine any structure or styles.
 
 ## Post List
 - 'Dumb' Component


### PR DESCRIPTION
This pull request creates a new 'MainPage' component, its container, and several sub components, some of which will be reused on other 'page' components.  For now the two pages that it's meant to replace are still in the repo, but they will be removed in the future.  

Those components to be removed are:
- MainCategoryPage
- Home page

The one thing that is currently missing from the new implementation is some kind of sidebar filler for when we do not have a particular category selected.