### PR TITLE
auto set category for new posts

### DIFF
--- a/client/src/components/Modals/ModalWrapper.js
+++ b/client/src/components/Modals/ModalWrapper.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const ModalWrapper = props => {
   const handleBackgroundClick = e => {
-    if (e.target === e.currentTarget) props.closeModal();
+    if (e.target === e.currentTarget) props.closeModal(e);
   };
 
   const onOk = () => {
@@ -22,7 +22,7 @@ const ModalWrapper = props => {
   return (
     <React.Fragment>
       <div>
-        <div onClick={handleBackgroundClick} id="overlay"></div>
+        <div onClick={props.disableBackgroundClick ? () => { } : handleBackgroundClick} id="overlay"></div>
         <div className={`${props.width} modalTop bg-body-background ml-auto mr-auto p-4 border border-mack-the-knife pin-x absolute rounded-lg shadow-lg mt-32 z-10 mb-3`}>
           <i onClick={props.closeModal} className="fas fa-times float-right cursor-pointer text-light-gray"></i>
           {props.children}

--- a/client/src/components/Modals/PublishPostModal.js
+++ b/client/src/components/Modals/PublishPostModal.js
@@ -7,9 +7,11 @@ import { TextArea, B } from '../Widgets'
 
 class PublishPostModal extends React.Component {
   render() {
+    console.log('PublishPostModal props: ', this.props)
     return (
       <ModalWrapper
         closeModal={this.props.closeModal}
+        disableBackgroundClick={true}
         width={'w-3/5'}
       >
         <div className='font-header text-light-gray text-2xl text-center'>Publish Post Settings</div>
@@ -19,6 +21,7 @@ class PublishPostModal extends React.Component {
           <Select
             className="z-100 text-base"
             placeholder='Category'
+            closeMenuOnSelect={true}
             onChange={this.props.onCategorySelectChange}
             options={this.props.categories}
             styles={colourStyles}
@@ -38,7 +41,7 @@ class PublishPostModal extends React.Component {
           </p>}
         </div>
         <div className='mb-4'>
-        <p className='mb-2 text-sm text-light-gray text-text-center'>Tags:</p>
+          <p className='mb-2 text-sm text-light-gray text-text-center'>Tags:</p>
           <Select
             id='tagField'
             className='react-select-container'
@@ -59,13 +62,13 @@ class PublishPostModal extends React.Component {
         <div className='h-8 text-light-gray text-sm'>
           <label htmlFor='paywall-active-box'>Enable Paywall:</label>
           <input
-              onChange={this.props.togglePaywall}
-              id='paywall-active-box'
-              type='checkbox'
-              checked={this.props.isPaywallActive}
-              className='h-4 w-4'
-            />
-          
+            onChange={this.props.togglePaywall}
+            id='paywall-active-box'
+            type='checkbox'
+            checked={this.props.isPaywallActive}
+            className='h-4 w-4'
+          />
+
         </div>
         {this.props.isPaywallActive &&
           <div className='w-full mb-3 text-sm text-light-gray'>
@@ -98,7 +101,7 @@ class PublishPostModal extends React.Component {
         </div>
         {/* <Button onClick={this.props.publishPost} text='Publish' disabled={!this.props.readyToPublish}></Button> */}
         <div className='text-right'>
-          <B onClick={this.props.publishPost} btnType={'secondary'} disabled={!this.props.readyToPublish}>Publish</B> 
+          <B onClick={this.props.publishPost} btnType={'secondary'} disabled={!this.props.readyToPublish}>Publish</B>
           <span className='mr-2'></span>
           <B onClick={this.props.closeModal} btnType={'secondary'}>Cancel</B>
           {/* <Button onClick={this.props.closeModal} text='Cancel'>Ok</Button> */}

--- a/client/src/components/Modals/PublishPostModalContainer.js
+++ b/client/src/components/Modals/PublishPostModalContainer.js
@@ -23,6 +23,16 @@ class PublishPostModalContainer extends React.Component {
   onTeaserChange = e => this.setState({ teaser: e.target.value })
   onPaywallCostChange = e => this.setState({ paywallCost: e.target.value })
 
+  componentDidMount() {
+    if (this.state.categoryName) {
+      const categoryObject = this.state.categories.find(c => c.value === this.state.categoryName)
+      const categoryDisplayName = categoryObject ? categoryObject.label : null
+      this.setState({
+        categoryDisplayName: categoryDisplayName
+      })
+    }
+  }
+
   togglePaywall = e => {
     const active = e.target.checked
     this.setState({

--- a/client/src/pages/Editor/EditorPageContainer.js
+++ b/client/src/pages/Editor/EditorPageContainer.js
@@ -8,7 +8,7 @@ import EditorPage from './EditorPage'
 class EditorPageContainer extends React.Component {
   constructor(props) {
     super(props)
-    const initialCategoryName = this.props.match.categoryId || ''
+    const initialCategoryName = this.props.match.params.categoryName || ''
 
     this.state = {
       editorState: EditorState.createEmpty(),
@@ -81,7 +81,8 @@ class EditorPageContainer extends React.Component {
     const data = {
       title: `Untitled ${new Date().toDateString()}`,
       body: 'And so it begins...',
-      isDraft: true
+      isDraft: true,
+      categoryName: this.props.match.params.categoryName
     }
     return API.createPost(data)
       .then(result => result.data)
@@ -138,6 +139,7 @@ class EditorPageContainer extends React.Component {
   };
 
   render() {
+    console.log('EditorPageContainer props: ', this.props)
     return (
       <EditorPage
         onEditorChange={this.onEditorChange}

--- a/client/src/pages/Main/MainPage.js
+++ b/client/src/pages/Main/MainPage.js
@@ -27,7 +27,7 @@ const MainPage = props => (
           <div>
             <AuthUserContext.Consumer>
               {authUser => authUser ?
-                <Link to={{ pathname: `/editor` }}>
+                <Link to={{ pathname: props.categoryName ? `/categories/${props.categoryName}/posts/new` : `/editor` }}>
                   <B btnType={'secondary'} >Create Post</B>
                 </Link> : null}
             </AuthUserContext.Consumer>


### PR DESCRIPTION
Also, disable the close modal function on bg click for the publish modal.  It was annoying when the tag select menu was long.

partial fix for #182 

The category is now correctly set when you click a 'create post' button on a category view page.  The other draft saving issues will be handled in another branch.
